### PR TITLE
fixed indention for connection call

### DIFF
--- a/openpyn/openpyn.py
+++ b/openpyn/openpyn.py
@@ -271,9 +271,9 @@ def run(
                     firewall.apply_fw_rules(network_interfaces, vpn_server_ip, skip_dns_patch)
                     if internally_allowed:
                         firewall.internally_allow_ports(network_interfaces, internally_allowed)
-            print(Fore.BLUE + "Out of the Best Available Servers, Chose",
-                      (Fore.GREEN + aserver + Fore.BLUE))
-            connection = connect(aserver, port, silent, test, skip_dns_patch)
+                print(Fore.BLUE + "Out of the Best Available Servers, Chose",
+                        (Fore.GREEN + aserver + Fore.BLUE))
+                connection = connect(aserver, port, silent, test, skip_dns_patch)
     elif server:
         # ask for and store credentials if not present, skip if "--test"
         if not test:


### PR DESCRIPTION
With the previous indention the connect() function would only be called after the 'for aserver in' loop went through the server list. This caused openpyn to always connect to the last server in the list which is pretty much the opposite of what we want.