### PR TITLE
more portable base path

### DIFF
--- a/openpyn/__init__.py
+++ b/openpyn/__init__.py
@@ -1,9 +1,10 @@
 import sys
+import os.path
 import subprocess
 
 __version__ = "2.4.2"
 __license__ = "GNU General Public License v3 or later (GPLv3+)"
-__basefilepath__ = "/usr/share/openpyn/"
+__basefilepath__ = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir)
 __data_files__ = []     # will be overwritten for non Mac OS
 
 if sys.platform == "linux":


### PR DESCRIPTION
Hi,
I've noticed the project uses fixed paths to define its root, but based on configuration/OS, etc, this is likely to change.

Wouldn't that be more portable with paths defined based on the location of the current file, as this PR proposes?