### PR TITLE
Hide pass

### DIFF
--- a/openpyn/credentials.py
+++ b/openpyn/credentials.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import getpass
 
 from colorama import Fore, Style
 from openpyn import __basefilepath__, root
@@ -22,7 +23,7 @@ def save_credentials():
               "compatible 'auth-user-pass' file format\n")
 
         username = input("Enter your username for NordVPN, i.e youremail@yourmail.com: ")
-        password = input("Enter the password for NordVPN: ")
+        password = getpass.getpass("Enter the password for NordVPN: ")
         try:
             with open(credentials_file_path, 'w') as creds:
                 creds.write(username + "\n")


### PR DESCRIPTION
This change uses the [getpass](https://docs.python.org/3.6/library/getpass.html) module to hide the user password when they are prompted for it.

Does not yet solve the issue of the credentials being stored in plain text in the `/usr/local/lib/python3.6/site-packages/openpyn-2.6.0-py3.6.egg/openpyn/credentials` file