### PR TITLE
Remove ovpn.zip before updating

### DIFF
--- a/openpyn/openpyn.py
+++ b/openpyn/openpyn.py
@@ -19,7 +19,7 @@ from openpyn import initd  # pylint: disable=W0406
 from openpyn import locations  # pylint: disable=W0406
 from openpyn import root  # pylint: disable=W0406
 from openpyn import systemd  # pylint: disable=W0406
-
+from pathlib import Path
 
 def main():
     parser = argparse.ArgumentParser(
@@ -517,6 +517,11 @@ def update_config_files():
     root.verify_root_access("Root access needed to write files in " +
                             "'" + __basefilepath__ + "files/" + "'")
     try:
+        _archive = Path(__basefilepath__ + "ovpn.zip")
+        if _archive.is_file():
+            print(Fore.BLUE + "Previous update file already exists, deleting..." + Style.RESET_ALL)
+            subprocess.run(["sudo", "rm", "-rf", _archive])
+
         subprocess.check_call(
             ["sudo", "wget", "https://downloads.nordcdn.com/configs/archives/servers/ovpn.zip", "-P", __basefilepath__])
     except subprocess.CalledProcessError:


### PR DESCRIPTION
In case of a KeyboardInterrupt during an update of the config file, the
next downloaded "ovpn.zip" will have a number appended to its file name,
(like "ovpn.zip.1" for example).
This can further cause issue with unzip:

"Archive:  /usr/lib/python3.6/site-packages/openpyn/ovpn.zip
Archive:  /usr/lib/python3.6/site-packages/openpyn/ovpn.zip
End-of-central-directory signature not found.  Either this file is not
a zipfile, or it constitutes one disk of a multi-part archive.  In the
latter case the central directory and zipfile comment will be found on
the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /usr/lib/python3.6/site-packages/openpyn/ovpn or
/usr/lib/python3.6/site-packages/openpyn/ovpn.zip, and cannot find /usr/lib/python3.6/site-packages/openpyn/ovpn.ZIP, period.
Exception occured while unzipping ovpn.zip, is unzip installed?"

Remove any "ovpn.zip" in __basefilepath__ before downloading new one.