### PR TITLE
2.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ or if they don't support OpenVPN \ (TCP or UDP depending upon which one you are 
 * NVRAM write support for Asuswrt-merlin
 * Pass through openvpn options, e.g. openpyn uk -o '--status /var/log/status.log --log /var/log/log.log'
 * Logs stored in '/var/log/openpyn/' for information and troubleshooting.
+* Temporarily disable ipv6 to prevent leakage (when using -f).
 
 ## Demo
 ![connection](https://user-images.githubusercontent.com/8462091/29347697-0798a52a-823e-11e7-818f-4dad1582e173.gif)
@@ -33,7 +34,7 @@ sudo apt install openvpn unzip wget python3-setuptools python3-pip
 ```
 2. The following python dependencies are needed and will be installed when using pip.
 ``` bash
-'requests', 'colorama', 'coloredlogs', 'verboselogs'
+requests colorama coloredlogs verboselogs
 ```
 ### Installation Methods
 1. Install openpyn with pip3 (Python=>3.5)
@@ -104,6 +105,7 @@ openpyn us -a ny
 openpyn us --area "new york"
 ```
 * To enforce Firewall rules to prevent dns leakage, also from ip leakage if tunnel breaks. i.e KILL SWITCH
+also temporarily disables ipv6 by running "sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1"
 ``` bash
 openpyn us -f # Experimental!, Warning, clears IPtables rules!
               # (changes are non persistent, simply reboot if having networking issues)

--- a/openpyn/__init__.py
+++ b/openpyn/__init__.py
@@ -4,7 +4,7 @@ import subprocess
 # import gc
 import verboselogs
 
-__version__ = "2.7.1"
+__version__ = "2.7.2.dev1"
 __license__ = "GNU General Public License v3 or later (GPLv3+)"
 __data_files__ = []
 __basefilepath__ = os.path.dirname(os.path.abspath(__file__)) + "/"

--- a/openpyn/__init__.py
+++ b/openpyn/__init__.py
@@ -4,7 +4,7 @@ import subprocess
 # import gc
 import verboselogs
 
-__version__ = "2.7.2.dev1"
+__version__ = "2.7.3.dev1"
 __license__ = "GNU General Public License v3 or later (GPLv3+)"
 __data_files__ = []
 __basefilepath__ = os.path.dirname(os.path.abspath(__file__)) + "/"

--- a/openpyn/__init__.py
+++ b/openpyn/__init__.py
@@ -3,7 +3,7 @@ import os.path
 import subprocess
 
 
-__version__ = "2.7.3.dev1"
+__version__ = "2.7.3"
 __license__ = "GNU General Public License v3 or later (GPLv3+)"
 __data_files__ = []
 __basefilepath__ = os.path.dirname(os.path.abspath(__file__)) + "/"

--- a/openpyn/__init__.py
+++ b/openpyn/__init__.py
@@ -2,7 +2,11 @@ import sys
 import os.path
 import subprocess
 
+<<<<<<< HEAD
 __version__ = "2.7.3.dev1"
+=======
+__version__ = "2.7.2"
+>>>>>>> master
 __license__ = "GNU General Public License v3 or later (GPLv3+)"
 __data_files__ = []
 __basefilepath__ = os.path.dirname(os.path.abspath(__file__)) + "/"

--- a/openpyn/__init__.py
+++ b/openpyn/__init__.py
@@ -2,11 +2,8 @@ import sys
 import os.path
 import subprocess
 
-<<<<<<< HEAD
+
 __version__ = "2.7.3.dev1"
-=======
-__version__ = "2.7.2"
->>>>>>> master
 __license__ = "GNU General Public License v3 or later (GPLv3+)"
 __data_files__ = []
 __basefilepath__ = os.path.dirname(os.path.abspath(__file__)) + "/"

--- a/openpyn/firewall.py
+++ b/openpyn/firewall.py
@@ -60,6 +60,16 @@ def apply_dns_rules():
     # do_dns(None, "0.0.0.0/0", "DROP")
 
 
+def disbale_ipv6():
+    try:
+        logger.info("Temporarily disabling ipv6 to prevent leakage")
+        subprocess.check_call(
+            ["sudo", "sysctl", "-w", "net.ipv6.conf.all.disable_ipv6=1"],
+            stdout=subprocess.DEVNULL)
+    except subprocess.SubprocessError:      # in case systemd is not used
+        logger.warning("Cant disable ipv6 using sysctl, are you even using systemd?")
+
+
 def apply_fw_rules(interfaces_details: List, vpn_server_ip: str, skip_dns_patch: bool) -> None:
     root.verify_root_access("Root access needed to modify 'iptables' rules")
 
@@ -68,6 +78,7 @@ def apply_fw_rules(interfaces_details: List, vpn_server_ip: str, skip_dns_patch:
     subprocess.check_call(["sudo", "iptables", "-F", "INPUT"])
 
     apply_dns_rules()
+    disbale_ipv6()
 
     # Allow all traffic out over the vpn tunnel
     # except for DNS, which is handled by systemd-resolved script

--- a/openpyn/firewall.py
+++ b/openpyn/firewall.py
@@ -81,7 +81,7 @@ def apply_fw_rules(interfaces_details: List, vpn_server_ip: str, skip_dns_patch:
     subprocess.check_call(["sudo", "iptables", "-F", "INPUT"])
 
     apply_dns_rules()
-    logger.info("Temporarily disabling ipv6 to prevent leakage")
+    logger.notice("Temporarily disabling ipv6 to prevent leakage")
     manage_ipv6(disable=True)
 
     # Allow all traffic out over the vpn tunnel

--- a/openpyn/firewall.py
+++ b/openpyn/firewall.py
@@ -7,6 +7,16 @@ from openpyn import root
 logger = logging.getLogger(__package__)
 
 
+def manage_ipv6(disable: bool) -> None:
+    value = 1 if disable else 0
+    try:
+        subprocess.check_call(
+            ["sudo", "sysctl", "-w", "net.ipv6.conf.all.disable_ipv6={}".format(value)],
+            stdout=subprocess.DEVNULL)
+    except subprocess.SubprocessError:      # in case systemd is not used
+        logger.warning("Cant disable/enable ipv6 using sysctl, are you even using systemd?")
+
+
 # Clears Firewall rules, applies basic rules.
 def clear_fw_rules() -> None:
     root.verify_root_access("Root access needed to modify 'iptables' rules")
@@ -60,16 +70,6 @@ def apply_dns_rules():
     # do_dns(None, "0.0.0.0/0", "DROP")
 
 
-def disbale_ipv6():
-    try:
-        logger.info("Temporarily disabling ipv6 to prevent leakage")
-        subprocess.check_call(
-            ["sudo", "sysctl", "-w", "net.ipv6.conf.all.disable_ipv6=1"],
-            stdout=subprocess.DEVNULL)
-    except subprocess.SubprocessError:      # in case systemd is not used
-        logger.warning("Cant disable ipv6 using sysctl, are you even using systemd?")
-
-
 def apply_fw_rules(interfaces_details: List, vpn_server_ip: str, skip_dns_patch: bool) -> None:
     root.verify_root_access("Root access needed to modify 'iptables' rules")
 
@@ -78,7 +78,8 @@ def apply_fw_rules(interfaces_details: List, vpn_server_ip: str, skip_dns_patch:
     subprocess.check_call(["sudo", "iptables", "-F", "INPUT"])
 
     apply_dns_rules()
-    disbale_ipv6()
+    logger.info("Temporarily disabling ipv6 to prevent leakage")
+    manage_ipv6(disable=True)
 
     # Allow all traffic out over the vpn tunnel
     # except for DNS, which is handled by systemd-resolved script

--- a/openpyn/management/management.py
+++ b/openpyn/management/management.py
@@ -148,10 +148,11 @@ def show(do_notify):
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Management interface for openpyn to display notifications ")
+        description="Management interface for openpyn to display notifications and log"
+        "them to /var/log/openpyn/openpyn-notifications.log ")
     parser.add_argument(
-        '--do-notify', dest='do_notify', help='try to show desktop notifications\
-        .', action='store_true')
+        '--do-notify', dest='do_notify', help='try to display desktop notifications.',
+        action='store_true')
 
     return parser.parse_args(argv[1:])
 

--- a/openpyn/management/management.py
+++ b/openpyn/management/management.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
+import argparse
 import logging
 import logging.handlers
 import os
 import socket
 import sys
 from time import sleep
+from typing import List
 
 from openpyn import log_folder, log_format
 
@@ -21,30 +23,30 @@ file_handler.setFormatter(file_handler_formatter)
 logger.addHandler(file_handler)
 
 
-try:
-    import gi
-except ImportError:
-    logger.error("Python3-gi not found, expected on a non-gui os")
-    sys.exit()
-try:
-    gi.require_version('Notify', '0.7')
-    from gi.repository import Notify
-except ValueError:
-    logger.error("Notify 0.7 not found, expected on a non-gui os")
-    sys.exit()
-
-
 def socket_connect(server, port):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.connect((server, port))
     return s
 
 
-def show():
-    sleep(1)
+def show(do_notify):
     detected_os = sys.platform
-    if detected_os == "linux":
-        Notify.init("openpyn")
+    sleep(1)
+    if do_notify:
+        try:
+            import gi
+        except ImportError:
+            logger.error("Python3-gi not found, expected on a non-gui os")
+            sys.exit()
+        try:
+            gi.require_version('Notify', '0.7')
+            from gi.repository import Notify
+        except ValueError:
+            logger.error("Notify 0.7 not found, expected on a non-gui os")
+            sys.exit()
+
+        if detected_os == "linux":
+            Notify.init("openpyn")
 
     while True:
         try:
@@ -58,12 +60,14 @@ def show():
         summary = "Openpyn"
         body = "Initiating connection (If stuck here, try again)"
         if detected_os == "linux":
-            notification = Notify.Notification.new(summary, body)
-            notification.show()
-            logger.warning("'MANAGEMENT-NOTIFICATION'{} {}".format(summary, body))
+            if do_notify:
+                notification = Notify.Notification.new(summary, body)
+                notification.show()
+            logger.warning("{} {}".format(summary, body))
         elif detected_os == "darwin":
-            notification = "\"{}\" with title \"{}\"".format(body, summary)
-            os.system("""osascript -e 'display notification {}'""".format(notification))
+            if do_notify:
+                notification = "\"{}\" with title \"{}\"".format(body, summary)
+                os.system("""osascript -e 'display notification {}'""".format(notification))
         server_name = ""
         last_status_UP = False
         # s.send(str.encode("state on"))
@@ -82,13 +86,15 @@ def show():
                 # logger.debug('Received A DOWN' + data_str)
                 body = "Connection Down, Disconnected."
                 if detected_os == "linux":
-                    notification.update(summary, body)
-                    # Show again
-                    notification.show()
-                    logger.info("'MANAGEMENT-NOTIFICATION'{} {}".format(summary, body))
+                    if do_notify:
+                        notification.update(summary, body)
+                        # Show again
+                        notification.show()
+                    logger.info("{} {}".format(summary, body))
                 elif detected_os == "darwin":
-                    notification = "\"{}\" with title \"{}\"".format(body, summary)
-                    os.system("""osascript -e 'display notification {}'""".format(notification))
+                    if do_notify:
+                        notification = "\"{}\" with title \"{}\"".format(body, summary)
+                        os.system("""osascript -e 'display notification {}'""".format(notification))
 
             server_name_location = data_str.find("common_name=")
             # logger.debug(server_name_location)
@@ -98,13 +104,14 @@ def show():
                 # logger.debug("Both True and server_name %s", server_name)
                 body = "Connected! to " + server_name
                 if detected_os == "linux":
-                    notification.update(summary, body)
-                    # Show again
-                    notification.show()
-                    logger.info("'MANAGEMENT-NOTIFICATION'{} {}".format(summary, body))
+                    if do_notify:
+                        notification.update(summary, body)
+                        notification.show()
+                    logger.info("{} {}".format(summary, body))
                 elif detected_os == "darwin":
-                    notification = "\"{}\" with title \"{}\"".format(body, summary)
-                    os.system("""osascript -e 'display notification {}'""".format(notification))
+                    if do_notify:
+                        notification = "\"{}\" with title \"{}\"".format(body, summary)
+                        os.system("""osascript -e 'display notification {}'""".format(notification))
 
             # break of data stream is empty
             if not data:
@@ -113,27 +120,47 @@ def show():
     except KeyboardInterrupt:
         body = "Disconnected, Bye."
         if detected_os == "linux":
-            notification.update(summary, body)
-            notification.show()
-            logger.info("'MANAGEMENT-NOTIFICATION'{} {}".format(summary, body))
+            if do_notify:
+                notification.update(summary, body)
+                notification.show()
+            logger.info("{} {}".format(summary, body))
         elif detected_os == "darwin":
-            notification = "\"{}\" with title \"{}\"".format(body, summary)
-            os.system("""osascript -e 'display notification {}'""".format(notification))
+            if do_notify:
+                notification = "\"{}\" with title \"{}\"".format(body, summary)
+                os.system("""osascript -e 'display notification {}'""".format(notification))
         logger.info('Shutting down safely, please wait until process exits')
     except ConnectionResetError:
         body = "Disconnected, Bye. (ConnectionReset)"
         if detected_os == "linux":
-            notification.update(summary, body)
-            notification.show()
-            logger.info("'MANAGEMENT-NOTIFICATION'{} {}".format(summary, body))
+            if do_notify:
+                notification.update(summary, body)
+                notification.show()
+            logger.info("{} {}".format(summary, body))
         elif detected_os == "darwin":
-            notification = "\"{}\" with title \"{}\"".format(body, summary)
-            os.system("""osascript -e 'display notification {}'""".format(notification))
+            if do_notify:
+                notification = "\"{}\" with title \"{}\"".format(body, summary)
+                os.system("""osascript -e 'display notification {}'""".format(notification))
         sys.exit()
 
     s.close()
     return
 
 
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Management interface for openpyn to display notifications ")
+    parser.add_argument(
+        '--do-notify', dest='do_notify', help='try to show desktop notifications\
+        .', action='store_true')
+
+    return parser.parse_args(argv[1:])
+
+
+def main() -> bool:
+
+    args = parse_args(sys.argv)
+    return show(args.do_notify)
+
+
 if __name__ == '__main__':
-    show()
+    sys.exit(main())

--- a/openpyn/openpyn.py
+++ b/openpyn/openpyn.py
@@ -810,7 +810,8 @@ def uses_systemd_resolved() -> bool:
     return True
 
 
-def connect(server: str, port: str, silent: bool, test: bool, skip_dns_patch: bool, openvpn_options: str, server_provider="nordvpn") -> bool:
+def connect(server: str, port: str, silent: bool, test: bool, skip_dns_patch: bool,
+            openvpn_options: str, server_provider="nordvpn") -> bool:
     detected_os = sys.platform
     if server_provider == "nordvpn":
         if port == "tcp":

--- a/openpyn/openpyn.py
+++ b/openpyn/openpyn.py
@@ -293,7 +293,6 @@ def run(init: bool, server: str, country_code: str, country: str, area: str, tcp
             openpyn_options += " --nvram " + str(nvram)
         if openvpn_options:
             openpyn_options += " --openvpn-options '" + openvpn_options + "'"
-        openpyn_options += " --silent"      # always added in openpyn.service
         # logger.debug(openpyn_options)
         if subprocess.check_output(["/bin/uname", "-o"]).decode(sys.stdout.encoding).strip() == "ASUSWRT-Merlin":
             initd.update_service(openpyn_options, run=True)
@@ -312,6 +311,8 @@ def run(init: bool, server: str, country_code: str, country: str, area: str, tcp
     elif kill_flush:
         firewall.clear_fw_rules()      # also clear iptable rules
         # if --allow present, allow those ports internally
+        logger.info("Re-enabling ipv6")
+        firewall.manage_ipv6(disable=False)
         if internally_allowed:
             network_interfaces = get_network_interfaces()
             firewall.internally_allow_ports(network_interfaces, internally_allowed)
@@ -845,8 +846,9 @@ openpyn would have connected to server: " + server + " on port: " + port + " wit
         if detected_os == "linux" and root.running_with_sudo():
             logger.warning("Desktop notifications don't work when using 'sudo', run without it, \
 when asked, provide the sudo credentials")
-        else:
             subprocess.Popen("openpyn-management".split())
+        else:
+            subprocess.Popen("openpyn-management --do-notify".split())
     use_systemd_resolved = False
     use_resolvconf = False
     if detected_os == "linux":

--- a/openpyn/openpyn.py
+++ b/openpyn/openpyn.py
@@ -388,6 +388,9 @@ def run(init: bool, server: str, country_code: str, country: str, area: str, tcp
 
             # connect to chosen_servers, if one fails go to next
             for aserver in chosen_servers:
+                if stats:
+                    print(Style.BRIGHT + Fore.BLUE + "Out of the Best Available Servers, Chose",
+                          (Fore.GREEN + aserver + Fore.BLUE) + "\n")
                 # if "-f" used apply firewall rules
                 if force_fw_rules:
                     network_interfaces = get_network_interfaces()
@@ -399,9 +402,6 @@ def run(init: bool, server: str, country_code: str, country: str, area: str, tcp
                     # TODO return 0 on success else 1 in asus.run()
                     asus.run(aserver, country_code, nvram, "All", "adaptive", "Strict", tcp, test)
                     logger.success("SAVED SERVER " + aserver + " ON PORT " + port + " TO NVRAM")
-                if stats:
-                    print(Style.BRIGHT + Fore.BLUE + "Out of the Best Available Servers, \
-Chose", (Fore.GREEN + aserver + Fore.BLUE) + "\n")
                 return(connect(aserver, port, silent, test, skip_dns_patch, openvpn_options))
     elif server:
         # ask for and store credentials if not present, skip if "--test"

--- a/openpyn/openpyn.py
+++ b/openpyn/openpyn.py
@@ -183,11 +183,21 @@ def run(init: bool, server: str, country_code: str, country: str, area: str, tcp
         return 1
 
     # Add another rotating handler to log to .log files
-    file_handler = logging.handlers.TimedRotatingFileHandler(
-        log_folder + '/openpyn.log', when='W0', interval=4)
-    file_handler_formatter = logging.Formatter(log_format)
-    file_handler.setFormatter(file_handler_formatter)
-    logger.addHandler(file_handler)
+    # fix permissions if needed
+    for attempt in range(2):
+        try:
+            file_handler = logging.handlers.TimedRotatingFileHandler(
+                log_folder + '/openpyn.log', when='W0', interval=4)
+            file_handler_formatter = logging.Formatter(log_format)
+            file_handler.setFormatter(file_handler_formatter)
+            logger.addHandler(file_handler)
+        except PermissionError:
+            root.verify_root_access(
+                "Root access needed to set permissions of {}/openpyn.log".format(log_folder))
+            subprocess.run("sudo chmod 777 {}/openpyn.log".format(log_folder).split())
+            subprocess.run("sudo chmod 777 {}/openpyn-notifications.log".format(log_folder).split())
+        else:
+            break
 
     # In this case only log messages originating from this logger will show up on the terminal.
     coloredlogs.install(level="verbose", logger=logger, fmt=log_format,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'openpyn = openpyn.openpyn:main',
-            'openpyn-management = openpyn.management.management:show']},
+            'openpyn-management = openpyn.management.management:main']},
     data_files=__data_files__,
     include_package_data=True,
     exclude_package_data={'openpyn': ['creds', 'credentials', 'install.sh', '.gitignore']},

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
     include_package_data=True,
     exclude_package_data={'openpyn': ['creds', 'credentials', 'install.sh', '.gitignore']},
     long_description=full_description,
+    long_description_content_type='text/markdown',
     classifiers=[
         'Intended Audience :: End Users/Desktop',
         'Intended Audience :: System Administrators',


### PR DESCRIPTION
- Temporarily disable ipv6 when using '-f' #170 
- Log to var/log/openpyn/openpyn-management.log when using systemd as well #145 
- A root process (systemd service) can't display notifications to the user, that's why I seprated the process a bit of displaying notifications and sending them to log in /var/log/openpyn/openpyn-management.log. Now systemd service can also log.
- Get connection status info by

```
tail var/log/openpyn/openpyn-management.log
```
- Re-enable ipv6 with 'openpyn -x'
- Some visual tweaks