### PR TITLE
added --status

### DIFF
--- a/openpyn/__init__.py
+++ b/openpyn/__init__.py
@@ -3,7 +3,7 @@ import os.path
 import subprocess
 
 
-__version__ = "2.7.4"
+__version__ = "2.7.6.dev1"
 __license__ = "GNU General Public License v3 or later (GPLv3+)"
 __data_files__ = []
 __basefilepath__ = os.path.dirname(os.path.abspath(__file__)) + "/"

--- a/openpyn/management/management.py
+++ b/openpyn/management/management.py
@@ -131,7 +131,7 @@ def show(do_notify):
             if do_notify:
                 notification = "\"{}\" with title \"{}\"".format(body, summary)
                 os.system("""osascript -e 'display notification {}'""".format(notification))
-        logger.info('Shutting down safely, please wait until process exits')
+        # logger.info('Shutting down safely, please wait until process exits')
     except ConnectionResetError:
         body = "Disconnected, Bye. (ConnectionReset)"
         if detected_os == "linux":

--- a/openpyn/management/management.py
+++ b/openpyn/management/management.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-import logging.handlers
 import os
 import socket
 import sys
@@ -19,8 +18,8 @@ logger = logging.getLogger(__package__)
 logger.setLevel(logging.VERBOSE)
 
 # Add another rotating handler to log to .log files
-file_handler = logging.handlers.TimedRotatingFileHandler(
-    log_folder + '/openpyn-notifications.log', when='W0', interval=4)
+file_handler = logging.FileHandler(
+    log_folder + '/openpyn-notifications.log')
 file_handler_formatter = logging.Formatter(log_format)
 file_handler.setFormatter(file_handler_formatter)
 logger.addHandler(file_handler)

--- a/openpyn/scripts/update-systemd-resolved.sh
+++ b/openpyn/scripts/update-systemd-resolved.sh
@@ -73,6 +73,8 @@ dhcp_settings() {
 }
 
 up() {
+  # echo UP with date but strip timezone info
+  echo "UP $(date '+%T %F')" > /var/log/openpyn/status
   local link="$1"
   shift
   local if_index="$1"
@@ -137,6 +139,8 @@ up() {
 }
 
 down() {
+  # echo DOWN with date but strip timezone info
+  echo "DOWN $(date '+%T %F')" > /var/log/openpyn/status
   local link="$1"
   shift
   local if_index="$1"

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setuptools.setup(
     keywords=[
         'openvpn wrapper', 'nordvpn', 'nordvpn client', 'secure vpn',
         'vpn wrapper', 'private vpn', 'privacy'],
+    python_requires='>=3.5',
     install_requires=['requests', 'colorama', 'coloredlogs', 'verboselogs'],
     platforms=['GNU/Linux', 'Ubuntu', 'Debian', 'Kali', 'CentOS', 'Arch', 'Fedora'],
     packages=setuptools.find_packages(),


### PR DESCRIPTION
removed write permissions for others to folder "/var/log/openpyn" and execute permissions to files in it.
couldn't have Rotating logs to facilitate it, changed to single file logs.
added --status   stores status in "/var/log/openpyn/status"
store "openvpn --status" option's output to "/var/log/openpyn/openvpn-status"
Except FileNotFoundError when config file is not yet downloaded