### PR TITLE
Drop external dependencies and reduce usage of root

### DIFF
--- a/openpyn/__init__.py
+++ b/openpyn/__init__.py
@@ -9,7 +9,12 @@ __data_files__ = []
 __basefilepath__ = os.path.dirname(os.path.abspath(__file__)) + "/"
 
 log_format = "%(asctime)s [%(levelname)s] %(message)s"
-log_folder = "/var/log/openpyn"     # logs will be saved here
+
+_xdg_data_home = os.environ.get('XDG_DATA_HOME')
+if not _xdg_data_home:
+    _xdg_data_home = os.path.join(os.environ.get('HOME'), '.local', 'share')
+ovpn_folder = os.path.join(_xdg_data_home, 'openpyn', 'files')
+log_folder = os.path.join(_xdg_data_home, 'openpyn', 'logs')      # logs will be saved here
 
 
 if sys.platform == "linux":

--- a/openpyn/credentials.py
+++ b/openpyn/credentials.py
@@ -21,23 +21,18 @@ def save_credentials() -> None:
     if not sys.__stdin__.isatty():
         raise RuntimeError("Please run %s in interactive mode" % __name__)
 
-    if root.verify_running_as_root() is False:
-        raise RuntimeError("Please run as 'sudo openpyn --init' the first time. \
-Root access is needed to store credentials in '%s'." % credentials_file_path)
-    else:
-        logger.info("Storing credentials in '%s' with openvpn \
+    logger.info("Storing credentials in '%s' with openvpn \
 compatible 'auth-user-pass' file format", credentials_file_path)
 
-        username = input("Enter your username for NordVPN, i.e youremail@yourmail.com: ")
-        password = getpass.getpass("Enter the password for NordVPN: ")
-        try:
-            with open(credentials_file_path, 'w') as creds:
-                creds.write(username + "\n")
-                creds.write(password + "\n")
-            creds.close()
-            # Change file permission to 600
-            subprocess.check_call(["sudo", "chmod", "600", credentials_file_path])
+    username = input("Enter your username for NordVPN, i.e youremail@yourmail.com: ")
+    password = getpass.getpass("Enter the password for NordVPN: ")
+    try:
+        with open(credentials_file_path, 'w') as creds:
+            creds.write(username + "\n")
+            creds.write(password + "\n")
+        # Change file permission to 600
+        os.chmod(credentials_file_path, 0o600)
 
-            logger.info("Awesome, the credentials have been saved in '%s'", credentials_file_path)
-        except (IOError, OSError):
-            raise RuntimeError("IOError while creating 'credentials' file.")
+        logger.info("Awesome, the credentials have been saved in '%s'", credentials_file_path)
+    except (IOError, OSError):
+        raise RuntimeError("IOError while creating 'credentials' file.")

--- a/openpyn/systemd.py
+++ b/openpyn/systemd.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import shutil
 import subprocess
 import sys
 
@@ -26,8 +28,8 @@ def update_service(openpyn_options: str, run=False) -> None:
         kill_option = " --kill"
     openpyn_options = openpyn_options.replace("-d ", "")
     openpyn_options = openpyn_options.replace("--daemon", "")
-    openpyn_location = str(subprocess.check_output(["which", "openpyn"]))[2:-3]
-    sleep_location = str(subprocess.check_output(["which", "sleep"]))[2:-3]
+    openpyn_location = shutil.which("openpyn")
+    sleep_location = shutil.which("sleep")
 
     service_text = "[Unit]\nDescription=NordVPN connection manager\nWants=network-online.target\n" + \
         "After=network-online.target\nAfter=multi-user.target\n[Service]\nType=simple\nUser=root\n" + \
@@ -35,27 +37,25 @@ def update_service(openpyn_options: str, run=False) -> None:
         openpyn_location + " " + openpyn_options + "\nExecStop=" + openpyn_location + kill_option + \
         "\nStandardOutput=syslog\nStandardError=syslog\n[Install]\nWantedBy=multi-user.target\n"
 
-    with open("/etc/systemd/system/openpyn.service", "w+") as service_file:
-        service_file.write(service_text)
-        service_file.close()
+    _xdg_config_home = os.environ['XDG_CONFIG_HOME']
+    if not _xdg_config_home:
+        _xdg_config_home = os.path.expanduser(os.path.join('~', '.config'))
+    systemd_service_path = os.path.join(_xdg_config_home, 'systemd', 'user', 'openpyn.service')
+    with open(systemd_service_path, 'w') as fp:
+        fp.write(service_text)
 
     logger.notice("The Following config has been saved in openpyn.service. \
 You can Run it or/and Enable it with: 'sudo systemctl start openpyn', \
-'sudo systemctl enable openpyn' \n" + service_text)
+'systemctl --user enable openpyn' \n" + service_text)
 
-    subprocess.run(["systemctl", "daemon-reload"])
+    subprocess.run(["systemctl", "--user", "daemon-reload"])
     if run:
         daemon_running = subprocess.call(  # subprocess.run behaves differently
-            ["systemctl", "is-active", "openpyn"],
+            ["systemctl", "--user", "is-active", "openpyn"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         ) == 0
 
-        if daemon_running:
-            logger.notice("Restarting Openpyn by running 'systemctl restart openpyn'\n\
+        logger.notice("Restarting Openpyn by running 'systemctl restart openpyn'\n\
 To check VPN status, run 'systemctl status openpyn'")
-            subprocess.Popen(["systemctl", "restart", "openpyn"])
-        else:
-            logger.notice("Starting Openpyn by running 'systemctl start openpyn'\n\
-To check VPN status, run 'systemctl status openpyn'")
-            subprocess.Popen(["systemctl", "start", "openpyn"])
+        subprocess.Popen(["systemctl", "--user", "restart", "openpyn"])

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         'openvpn wrapper', 'nordvpn', 'nordvpn client', 'secure vpn',
         'vpn wrapper', 'private vpn', 'privacy'],
     python_requires='>=3.5',
-    install_requires=['requests', 'colorama', 'coloredlogs', 'verboselogs'],
+    install_requires=['colorama', 'coloredlogs', 'requests', 'tqdm', 'verboselogs'],
     tests_require=['pytest', 'mock'],
     platforms=['GNU/Linux', 'Ubuntu', 'Debian', 'Kali', 'CentOS', 'Arch', 'Fedora'],
     packages=setuptools.find_packages(),

--- a/tests/test_openpyn.py
+++ b/tests/test_openpyn.py
@@ -8,7 +8,7 @@ import logging.handlers
 import sys
 import time
 
-import mock
+from unittest import mock
 import pytest
 
 from openpyn import openpyn


### PR DESCRIPTION
I have removed the need for superuser access to store logs and VPN configuration, relying on user home locations instead. That makes it only needed to use root for connection, and I think that can be avoided too, so openpyn can be installed per user.

I also removed the need for external software such as `unzip` and `wget` by replacing with Python dependencies (`zipfile` and `requests`, respectively).

Edit: I intend to remove other `popen` calls if possible, replacing with Python code instead.