### PR TITLE
POC: Adding config based ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # openpyn
+<p align="center">
+<a href="https://pepy.tech/project/openpyn"><img alt="Downloads" src="https://pepy.tech/badge/openpyn"></a> </p>
 A python3 script (systemd service as well) to manage openvpn connections. Created to easily connect to and switch between, OpenVPN servers hosted by NordVPN. Quickly Connect to the least busy servers with lowest latency from you (using current data from Nordvpn's API). Find servers in a specific country or even a city. It Tunnels DNS traffic through the VPN which normally (when using OpenVPN) goes through your ISP's DNS (unencrypted) and compromises Privacy!
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ openpyn us -f # Experimental!, Warning, clears IPtables rules!
 ``` bash
 openpyn us -f --allow 22 80 443  #only accessible from local network
 ```
+* To allow ports from other ranges use the `--allow-config` or `--allow-config-json` options. More details can be found [here](./docs/allowed-ports-config.md)
 * To quickly connect to a specific server.
 ``` bash
 openpyn -s au10
@@ -238,6 +239,17 @@ optional arguments:
                         INTERNAL IP RANGE. e.g, you can use your PC as
                         SSH, HTTP server for local devices (e.g 192.168.1.*
                         range) by using "openpyn us -f --allow 22 80"
+
+  --allow-config INTERNALLY_ALLOWED_CONFIG
+                        To be used with "f" to allow a complex a complex set
+                        of allow port rules. This option requires a path to a
+                        JSON file that contains the relevent config
+
+  --allow-config-json INTERNALLY_ALLOWED_CONFIG_JSON
+                        To be used with "f" to allow a complex a complex set
+                        of allow port rules. This option requires works the
+                        same as "--allow-config" option but accepts a json
+                        object as a string instead
 
   --update              Fetch the latest config files from nord''s site
 

--- a/docs/allowed-ports-config.md
+++ b/docs/allowed-ports-config.md
@@ -1,0 +1,70 @@
+# Allowed ports config
+
+## Intro
+The allowed ports config is a json object used to specify exclutions before the the firewall is created.
+
+Note: Incorrectly applying these rules will result in the firewall not blocking all outgoing traffic. Only disable the `internal` option if you know what you are doing!
+## Setup
+This config can be loaded through two options
+
+- `--allow-config [string]` Specifies a path to a .json file containing the config.
+- `--allow-config-json [string]` Allows for the json string to be passed directly as an argument.
+
+## Schema
+```json
+[
+    {
+        "port": int || string,
+        "protocol": (optional) string,
+        "internal": (optional) bool
+        "allowed_ip_range": (optional) str[] || str
+    },
+    ...
+]
+```
+
+## Details
+
+### Port
+This option specifies what port(s) should be excluded by this rule. This option is required.
+
+Can either be passed as an integer between `1` and `65535`; a string or a port range in the form of `{port_lower}-{port_upper}`
+
+### Protocol
+This option defines the protocols the ports will be opened on. This defaults to `tcp`.
+
+This can be either be set to `tcp`, `udp` or `both`.
+
+### Internal
+This option specifies if ports should be only allowed on internal ip ranges. When set to `true` this will only allow ports to be exposed in the local network
+
+Note: this option is overridden if extra IPs are set in
+
+### Allowed IP Range
+This option specifies the ip(s) that the specified port(s) should be exposed to. This can either be a specific IP or an IP block.
+
+This can either be passed as a single ip (as a string) or an array of ips (as an array of srings). This can also be used 
+
+This defaults to null.
+
+## Examples
+```json
+[
+    {
+        "port": 22,
+        "protocol": "both"
+    }
+]
+```
+Expose on the external network port `22` on both `tcp` and `udp` protocols.
+
+```json
+[
+    {
+        "port": "137-139",
+        "protocol": "udp",
+        "internal": false
+    }
+]
+```
+Expose ports 137, 138 and 139 over UDP to the clear net while the firewall is up

--- a/openpyn/firewall.py
+++ b/openpyn/firewall.py
@@ -1,6 +1,10 @@
 import logging
 import subprocess
-from typing import List
+import os
+import json
+import itertools
+from jsonschema import Draft4Validator
+from typing import List, Dict
 
 import verboselogs
 
@@ -142,7 +146,6 @@ def apply_fw_rules(interfaces_details: List, vpn_server_ip: str, skip_dns_patch:
     subprocess.check_call("sudo iptables -P INPUT DROP".split())
     return
 
-
 # open sepecified ports for devices in the local network
 def internally_allow_ports(interfaces_details: List, internally_allowed: List) -> None:
     for interface in interfaces_details:
@@ -153,3 +156,161 @@ def internally_allow_ports(interfaces_details: List, internally_allowed: List) -
                 subprocess.call(
                     ("sudo iptables -A INPUT -p tcp --dport " + port + " -i " +
                         interface[0] + " -s " + interface[2] + " -j ACCEPT").split())
+
+#Converts the allwed ports config to a series of iptable rules and applies them
+def apply_allowed_port_rules(interfaces_details: List, allowed_ports_config: List) -> bool:
+
+    if not validate_allowed_ports_json(allowed_ports_config):
+        return False
+
+    root.verify_root_access("Root access needed to pre load fire wall rules")
+
+    DEFAULT_PORT_CONFIG = {
+        "internal": True,
+        "protocol": "tcp",
+        "allowed_ip_range": None
+    }
+    
+    #Merge default config with existing config
+    allowed_ports_config = [{**DEFAULT_PORT_CONFIG, **port_config} for port_config in allowed_ports_config]
+
+    ip_table_rules = []
+
+    for port_config in allowed_ports_config:
+        #Get perms for the connection type
+        port_protocol_permiatations = []
+
+        if port_config['protocol'] in ['tcp' , 'both']:
+            port_protocol_permiatations.append('tcp')
+        
+        if port_config['protocol'] in ['udp', 'both']:
+            port_protocol_permiatations.append('udp')
+        
+        #Create the flags for the port range / port
+        if '-' in str(port_config['port']):
+            port_range = port_config['port'].split('-')
+            port_flag = '--match multiport --dports {0}:{1}'.format(*port_range)
+        else:
+            port_flag = '--dport {0}'.format(port_config['port'])
+
+        for interface, port_type in itertools.product(interfaces_details, port_protocol_permiatations):
+            #Skip any tunnel interfaces that might be invalid
+            if len(interface) != 3 or "tun" in interface[0]:
+                continue
+            
+            ip_flag = ''
+            ip_ranges = []
+            
+            if port_config['internal']:
+                ip_ranges.append(interface[2])
+            
+            if port_config['allowed_ip_range'] != None:
+                if isinstance(port_config['allowed_ip_range'], list):
+                    ip_ranges += port_config['allowed_ip_range']
+                else:
+                    ip_ranges.append(port_config['allowed_ip_range'])
+                
+
+            if ip_ranges != []:
+                ip_flag = ' -s '+ ','.join(ip_ranges)
+
+            ip_table_rules.append("sudo iptables -A INPUT -p {port_type} {port_flag} -i {interface}{ip_flag} -j ACCEPT".format(
+                port_type=port_type, port_flag=port_flag, interface=interface[0], ip_flag=ip_flag
+            ))
+
+    for rule in ip_table_rules:
+        subprocess.call(rule.split(' '))
+
+    return True    
+
+# Load allowed ports config from path (does not include validation)
+def load_allowed_ports(path_to_allowed_ports: str) -> bool:
+    #Ensure paths are resolved to real paths
+    path_to_allowed_ports = os.path.realpath(path_to_allowed_ports)
+
+    if not os.path.isfile(path_to_allowed_ports) :
+        logger.warn("Connot preload allowed ports: file {0} does not exist".format(path_to_allowed_ports))
+        return False
+    
+    try:
+        with open(path_to_allowed_ports, 'rt') as file_handle:
+            try:
+                allowed_ports_config = json.load(file_handle)
+            except json.JSONDecodeError as json_decode_error:
+                logger.error("Failed to decode allowed ports JSON")
+                return False
+
+        
+    except EnvironmentError as file_read_error:
+        logger.error("Connot preload allowed ports: failed to load \"{filename}\" {strerr}".format(filename = file_read_error.filename, strerr=file_read_error.strerror))
+
+    return allowed_ports_config
+
+#Validates if the allowed ports json is valid before loading it
+def validate_allowed_ports_json(allowed_ports_config: Dict) -> bool:
+    validation_schema = {
+        "description": "Root config node",
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "port" : { 
+                    "anyOf": [
+                        {
+                            "name": "Port number",
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 65535
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\d{1,5}(-\\d{1,5})?$"
+                        }
+                    ]
+                },
+                "protocol": {
+                    "type": "string",
+                    "pattern": "^(tcp|ip|both)$"
+                },
+                "internal": {
+                    "type": "boolean",
+                },
+                "allowed_ip_range": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ip_address_block"
+                        },
+                        {
+                            "items": {"$ref": "#/definitions/ip_address_block"},
+                            "uniqueItems": True
+                        }
+                    ]
+                    
+                }
+            },
+            "required": ["port"]
+        },
+        "definitions": {
+            "ip_address_block": {
+                "type": "string",
+                "pattern": "^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$"
+            }
+        }
+    }
+    
+    #Create the config validator
+    allowed_ports_config_validator = Draft4Validator(validation_schema)
+    
+    #If the passed config is not valid enumerate errors and print them in human readable form
+    if not allowed_ports_config_validator.is_valid(allowed_ports_config):
+        
+        error_message = "Errors were raise when validating the allowed ports config:"
+        #Retrieve all validation errors yielded in schema
+        for validation_error in allowed_ports_config_validator.iter_errors(allowed_ports_config):
+            error_message += "\n\nError at root.{0} in config: {1}".format('.'.join([str(part) for part in validation_error.absolute_path]), validation_error.message)
+        
+        logger.error(error_message)
+        
+        return False
+
+    return True

--- a/openpyn/initd.py
+++ b/openpyn/initd.py
@@ -4,6 +4,8 @@ import logging
 import os
 import subprocess
 import sys
+import shlex
+import json
 
 import verboselogs
 
@@ -44,6 +46,7 @@ Default(Just Press Enter) is, uk : ") or "uk"
     parser.add_argument('--skip-dns-patch', dest='skip_dns_patch')
     parser.add_argument('-f', '--force-fw-rules')
     parser.add_argument('--allow', dest='internally_allowed')
+    parser.add_argument('--allow-config-json', dest='internally_allowed_config_json')
     # parser.add_argument('-l', '--list', dest="list_servers", type=str, nargs='?', default="nope")
     parser.add_argument('--silent')
     parser.add_argument('--p2p')
@@ -83,6 +86,7 @@ Default(Just Press Enter) is, uk : ") or "uk"
     netflix = args.netflix
     test = args.test
     internally_allowed = args.internally_allowed
+    internally_allowed_config_json = args.internally_allowed_config_json
     skip_dns_patch = args.skip_dns_patch
     silent = args.silent
     nvram = args.nvram
@@ -146,6 +150,9 @@ Default(Just Press Enter) is, uk : ") or "uk"
         for port_number in internally_allowed:
             open_ports += " " + port_number
         openpyn_options += " --allow" + open_ports
+    if internally_allowed_config_json:
+        #Assume at this stage the json has been passed as string so it can be directly loaded
+        openpyn_options += " --allow-config-json=" + internally_allowed_config_json
     if skip_dns_patch:
         openpyn_options += " --skip-dns-patch"
     if silent:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     keywords=[
         'openvpn wrapper', 'nordvpn', 'nordvpn client', 'secure vpn',
         'vpn wrapper', 'private vpn', 'privacy'],
-    install_requires=['requests', 'colorama', 'coloredlogs', 'verboselogs'],
+    install_requires=['requests', 'colorama', 'coloredlogs', 'verboselogs', 'jsonschema'],
     tests_require=['pytest', 'mock'],
     platforms=['GNU/Linux', 'Ubuntu', 'Debian', 'Kali', 'CentOS', 'Arch', 'Fedora'],
     packages=setuptools.find_packages(),


### PR DESCRIPTION
# What is this?
This PR is a preposed solution to the issues outlined here https://github.com/jotyGill/openpyn-nordvpn/issues/228. It aims to add more customisation to the ports exposed when using the `-f` option.

# How does it work?
A new set of options (`--allow-config` and `--allow-config-json`) have been added. These options load a JSON config object that gets converted into a series of ip table rules that get loaded before the firewall to exclude certain ports.

# Current state
This code had been tested in a docker env (which I can add to a separate PR if there is interest in that) that does not fully cover all of the code In this PR. More testing will be needed on this front if we do want to go forwards with this idea. Additionally we will likely want to add testing around this before merging

Let me know if this is set up ok as it is my first real Open Source PR 😄! 

Any commentary on it would be of great help