### PR TITLE
Add /usr/sbin in $PATH for update-systemd-resolved.sh script

### DIFF
--- a/openpyn/scripts/update-systemd-resolved.sh
+++ b/openpyn/scripts/update-systemd-resolved.sh
@@ -28,6 +28,7 @@
 # Define what needs to be called via DBus
 DBUS_DEST="org.freedesktop.resolve1"
 DBUS_NODE="/org/freedesktop/resolve1"
+PATH="$PATH:/usr/sbin"
 
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 


### PR DESCRIPTION
Hi,

In fedora 30, ip binary is in /usr/sbin directory.
So I just added /usr/sbin in $PATH. This way, openvpn is able to execute the [command](https://github.com/jotyGill/openpyn-nordvpn/blob/e6ffebf90b7c61a4a1d62f43f3d8753ab6097917/openpyn/scripts/update-systemd-resolved.sh#L61) in update-systemd-resolved.sh.

Also, this issue has been faced in #231, but not fixed upstream.
