### PR TITLE
Add MacOS manual DNS patch and revert

### DIFF
--- a/openpyn/openpyn.py
+++ b/openpyn/openpyn.py
@@ -254,7 +254,6 @@ def run(init: bool, server: str, country_code: str, country: str, area: str, tcp
     else:
         force_fw_rules = False
         internally_allowed = None
-        skip_dns_patch = True
         nvram = None
 
     # check if dependencies are installed
@@ -588,6 +587,9 @@ def run(init: bool, server: str, country_code: str, country: str, area: str, tcp
 
     else:
         logger.info("To see usage options type: 'openpyn -h' or 'openpyn --help'")
+
+    # Darwin: Revert /etc/resolv.conf back to the original if it was modified
+    subprocess.call(["sudo", __basefilepath__ + "scripts/revert-manual-dns-patch.sh"])
 
     # if everything went ok
     return 0

--- a/openpyn/scripts/manual-dns-patch.sh
+++ b/openpyn/scripts/manual-dns-patch.sh
@@ -9,6 +9,10 @@ echo "nameserver nordDNS1 = $nordDNS1"
 echo "nameserver nordDNS2 = $nordDNS2"
 echo "nameserver openDNS3 = $openDNS3"
 
+# try to move current resolv.conf to a backup file before overwriting
+# if backup already exists, do not overwrite backup
+mv -n /etc/resolv.conf /etc/resolv.conf.backup
+
 echo "nameserver $nordDNS1" >  /etc/resolv.conf
 echo "nameserver $nordDNS2" >> /etc/resolv.conf
 echo "nameserver $openDNS3" >> /etc/resolv.conf

--- a/openpyn/scripts/revert-manual-dns-patch.sh
+++ b/openpyn/scripts/revert-manual-dns-patch.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+echo "Reverting /etc/resolv.conf back to original"
+
+# force overwrites resolv.conf with the backup
+mv -f /etc/resolv.conf.backup /etc/resolv.conf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+attrs==19.3.0
+certifi==2019.11.28
+chardet==3.0.4
+colorama==0.4.3
+coloredlogs==10.0
+humanfriendly==4.18
+idna==2.8
+jsonschema==3.2.0
+pyrsistent==0.15.6
+requests==2.22.0
+six==1.13.0
+tqdm==4.40.2
+urllib3==1.25.7
+verboselogs==1.7


### PR DESCRIPTION
### Description

- Removed the hard-coded `skip_dns_patch = True` to allow manual patching of `/etc/resolv.conf` on Mac OS (`darwin`)
- Original `/etc/resolv.conf` is moved to `/etc/resolv.conf.backup` before overwrite
- Added script that is called as final step before shutting down that uses the backup file to overwrite the patched `/etc/resolv.conf` file; backup file is removed in this process (`mv -f`)
- Added `requirements.txt` file for local development / IDE help e.g. `pip install -r requirements.txt`

### Testing

- Ran locally on Mac OS Catalina version 10.15.1 and observed:
  1. `/etc/resolv.conf` being overwritten with values from `manual-dns-patch.sh` after original conf file is moved to `/etc/resolv.conf.backup`
  1. On SystemExit (using KeyboardInterrupt) observed `/etc/resolv.conf.backup` being used to overwrite `/etc/resolv.conf`
  1. Checked values before / after and they are accurate

### Note

Running the subprocess as the final step before exiting seems pretty sloppy but this is currently just a hacky fix. If openpyn is force killed or quits in a way that doesn't allow it to shutdown gracefully then `/etc/resolv.conf` will be replaced on next system restart (Mac OS automatic process from my understanding). The `/etc/resolv.conf.backup` file will hang around though. 🤔 